### PR TITLE
Craft Cloud compatibility

### DIFF
--- a/src/assetbundles/cookieconsentbanner/CookieConsentBannerAsset.php
+++ b/src/assetbundles/cookieconsentbanner/CookieConsentBannerAsset.php
@@ -45,21 +45,21 @@ class CookieConsentBannerAsset extends AssetBundle
         // define the path that your publishable resources live
         $this->sourcePath = "@adigital/cookieconsentbanner/assetbundles/cookieconsentbanner/dist";
 
-        $settings = \adigital\cookieconsentbanner\CookieConsentBanner::getInstance()->getSettings();
+        $settings = \adigital\cookieconsentbanner\CookieConsentBanner::getInstance()?->getSettings();
 
         $jsOptions = [];
 
-        if($settings->async_js) {
+        if($settings?->async_js) {
 	        $jsOptions["async"] = "async";
         }
 
-        if($settings->defer_js) {
+        if($settings?->defer_js) {
 	        $jsOptions["defer"] = "defer";
         }
 
         $cssOptions = [];
 
-        if($settings->preload_css) {
+        if($settings?->preload_css) {
 	        $cssOptions["rel"] = "preload";
           $cssOptions["as"] = "style";
         }


### PR DESCRIPTION
Craft Cloud pre-publishes asset bundles to a CDN, and must be able to do that without Craft installed.
This PR makes the asset bundle valid even if no instance of the plugin can be retrieved.